### PR TITLE
PRKT-80 ScanDataPolar ScanDataXY Timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - 2021-06-28
+## [2.0.0] - In-Development
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
+- Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created
 
 ## [1.1.0] - 2021-06-21
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(Parakeet VERSION 1.2.0)
+project(Parakeet VERSION 2.0.0)
 
 set (PROJECT_VERSION_STRING ${PROJECT_NAME}-${PROJECT_VERSION})
 

--- a/include/parakeet/Driver.h
+++ b/include/parakeet/Driver.h
@@ -141,6 +141,7 @@ class Driver
         std::chrono::milliseconds interfaceThreadStartTime;
         int interfaceThreadFrameCount = 0;
 
+        std::chrono::time_point<std::chrono::system_clock> timeOfFirstPoint;
         std::vector<PointPolar> pointHoldingList;
         std::function<void(const ScanDataPolar&)> scanCallbackFunction = nullptr;
 

--- a/include/parakeet/ScanDataPolar.h
+++ b/include/parakeet/ScanDataPolar.h
@@ -18,15 +18,14 @@ class ScanDataPolar
     public:
         /// \brief Create a ScanDataPolar which is responsible for holding on to a list of PointPolars
         /// \param[in] pointPolarList - A vector containing PointPolar(s)
-        /// \returns A ScanDataPolar object which holds the information given through the param, and generates a timestamp.
-        ScanDataPolar(const std::vector<PointPolar>& pointPolarList);
+        /// \param[in] timestamp - A time point which holds the time the first point was received
+        /// \returns A ScanDataPolar object which holds a vector of PointPolar(s) and a timestamp
+        ScanDataPolar(const std::vector<PointPolar>& pointPolarList, const std::chrono::time_point<std::chrono::system_clock>& timestamp);
         
         /// \brief Returns the vector of points this object is holding onto
-        /// \returns Vector of points this object is holding onto
         const std::vector<PointPolar>& getPoints() const;
         
-        /// \brief Returns the timestamp of this objects creation
-        /// \returns Timestamp of this objects creation
+        /// \brief Returns the timestamp which signals when the first point was received
         const std::chrono::time_point<std::chrono::system_clock>& getTimestamp() const;
 
     private:

--- a/include/parakeet/ScanDataXY.h
+++ b/include/parakeet/ScanDataXY.h
@@ -18,15 +18,14 @@ class ScanDataXY
     public:
         /// \brief Create a ScanDataXY which is responsible for holding on to a list of PointXYs
         /// \param[in] pointPolarList - A vector containing PointXY(s)
-        /// \returns A ScanDataXY object which holds the information given through the param, and generates a timestamp.
-        ScanDataXY(const std::vector<PointXY>& pointXYList);
+        /// \param[in] timestamp - A time point which holds the time the first point was received
+        /// \returns A ScanDataXY object which holds a vector of PointXY(s) and a timestamp
+        ScanDataXY(const std::vector<PointXY>& pointXYList, const std::chrono::time_point<std::chrono::system_clock>& timestamp);
         
         /// \brief Returns the vector of points this object is holding onto
-        /// \returns Vector of points this object is holding onto
         const std::vector<PointXY>& getPoints() const;
         
-        /// \brief Returns the timestamp of this objects creation
-        /// \returns Timestamp of this objects creation
+        /// \brief Returns the timestamp which signals when the first point was received
         const std::chrono::time_point<std::chrono::system_clock>& getTimestamp() const;
 
     private:

--- a/src/parakeet/Driver.cpp
+++ b/src/parakeet/Driver.cpp
@@ -380,6 +380,11 @@ namespace parakeet
 
     void Driver::OnData(ScanData* data)
     {
+        if(pointHoldingList.size() == 0)
+        {
+            timeOfFirstPoint = std::chrono::system_clock::now();
+        }
+
         double startAngle_deg = data->from / 10.0;
         double endAngle_deg = (static_cast<double>(data->from) + static_cast<double>(data->span)) / 10.0;
         double anglePerPoint_deg = (endAngle_deg - startAngle_deg) / data->count;
@@ -388,20 +393,20 @@ namespace parakeet
         //Create PointPolar for each data point
         for(int i = 0; i < data->count; i++)
         {
-            PointPolar p(data->dist[i], startAngle_deg + (anglePerPoint_deg * i), data->intensity[i]);
+            PointPolar pointPolar(data->dist[i], startAngle_deg + (anglePerPoint_deg * i), data->intensity[i]);
 
-            pointHoldingList.push_back(p);
+            pointHoldingList.push_back(pointPolar);
         }
 
         if(endAngle_deg + deviationFrom360_deg >= 360)
         {
             interfaceThreadFrameCount++;
 
-            ScanDataPolar sdp(pointHoldingList);
+            ScanDataPolar scanDataPolar(pointHoldingList, timeOfFirstPoint);
 
             if (scanCallbackFunction != nullptr)
             {
-                scanCallbackFunction(sdp);
+                scanCallbackFunction(scanDataPolar);
             }
 
             pointHoldingList.clear();

--- a/src/parakeet/ScanDataPolar.cpp
+++ b/src/parakeet/ScanDataPolar.cpp
@@ -8,9 +8,9 @@ namespace mechaspin
 {
 namespace parakeet
 {
-    ScanDataPolar::ScanDataPolar(const std::vector<PointPolar>& pointPolarList)
+    ScanDataPolar::ScanDataPolar(const std::vector<PointPolar>& pointPolarList, const std::chrono::time_point<std::chrono::system_clock>& timestamp)
     {
-        timestamp = std::chrono::system_clock::now();
+        this->timestamp = timestamp;
         points_mm = pointPolarList;
     }
 

--- a/src/parakeet/ScanDataXY.cpp
+++ b/src/parakeet/ScanDataXY.cpp
@@ -8,9 +8,9 @@ namespace mechaspin
 {
 namespace parakeet
 {
-    ScanDataXY::ScanDataXY(const std::vector<PointXY>& pointXYList)
+    ScanDataXY::ScanDataXY(const std::vector<PointXY>& pointXYList, const std::chrono::time_point<std::chrono::system_clock>& timestamp)
     {
-        timestamp = std::chrono::system_clock::now();
+        this->timestamp = timestamp;
         points_mm = pointXYList;
     }
 

--- a/src/parakeet/util.cpp
+++ b/src/parakeet/util.cpp
@@ -16,7 +16,7 @@ namespace parakeet
         {
             pointXYvector.push_back(transform(point));
         }
-        return ScanDataXY(pointXYvector);
+        return ScanDataXY(pointXYvector, polarScanData.getTimestamp());
     }
 
     PointXY util::transform(const PointPolar& polarPoint)


### PR DESCRIPTION
Changed ScanDataPolar / ScanDataXY to require a timestamp, which signifies when the first point was created, during construction.