### PR TITLE
PRKT-76 Document Start Angle of Sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0] - In-Development
+### Added
+- Added sensor starting angle and spin rotation to the documentation
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
 - Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Parakeet-SDK
 
-Driver library for the Parakeet Pro LiDAR Sensor.
+Driver library for the Parakeet Pro LiDAR sensor.
 
 Documentation for building and installing the library can be found [here](docs/Building%20and%20Installing.md).
 
-## Windows Requirements
+## Additional information
 
 The CP210x USB to UART Bridge connector needs a specific driver installed to be used on Windows. You can find the latest driver [here](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers).
+
+The Parakeet-Pro LiDAR sensor has its starting angle of 0 in the center of the device, on the opposite side of the serial port. The device spins clockwise.
 
 ## Test Apps
 


### PR DESCRIPTION
Added a section to the documentation describing the start angle of the Parakeet Pro sensor and the direction the disk spins.