### PR TITLE
PRKT-83 Remove Deprecated Functions for v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
 - Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created
 - Modified SimpleExample CMake to find the latest version of parakeet-sdk which can be found
+### Removed
+- Removed deprecated functions getRange, and getAngleInDegrees from PointPolar
+- Removed deprecated functions getX, and getY from PointXY
 
 ## [1.1.0] - 2021-06-21
 ### Added

--- a/include/parakeet/PointPolar.h
+++ b/include/parakeet/PointPolar.h
@@ -21,19 +21,9 @@ class PointPolar
         /// \returns A PointPolar object which holds the information given through the params.
         PointPolar(double range_mm, double angle_deg, std::uint16_t intensity);
 
-        /// \deprecated Replaced by getRange_mm()
-        /// \brief Returns the distance, in millimeters, from the origin
-        /// \returns Distance, in millimeters, from the origin
-        PARAKEET_DEPRECATED(double getRange() const);
-
         /// \brief Returns the distance, in millimeters, from the origin
         /// \returns Distance, in millimeters, from the origin
         double getRange_mm() const;
-
-        /// \deprecated Replaced by getAngle_deg()
-        /// \brief Returns the polar angle in degree form
-        /// \returns Polar angle in degree form
-        PARAKEET_DEPRECATED(double getAngleInDegrees() const);
 
         /// \brief Returns the polar angle in degree form
         /// \returns Polar angle in degree form

--- a/include/parakeet/PointXY.h
+++ b/include/parakeet/PointXY.h
@@ -21,16 +21,6 @@ class PointXY
         /// \returns A PointXY object which holds the information given through the params.
         PointXY(double x_mm, double y_mm, std::uint16_t intensity);
 
-        /// \deprecated Replaced by getX_mm()
-        /// \brief Returns the distance, in millimeters, from the origin in the X direction
-        /// \returns Distance, in millimeters, from the origin in the X direction
-        PARAKEET_DEPRECATED(double getX() const);
-
-        /// \deprecated Replaced by getY_mm()
-        /// \brief Returns the distance, in millimeters, from the origin in the Y direction
-        /// \returns Distance, in millimeters, from the origin in the Y direction
-        PARAKEET_DEPRECATED(double getY() const);
-
         /// \brief Returns the distance, in millimeters, from the origin in the X direction
         /// \returns Distance, in millimeters, from the origin in the X direction
         double getX_mm() const;

--- a/src/parakeet/PointPolar.cpp
+++ b/src/parakeet/PointPolar.cpp
@@ -15,19 +15,9 @@ namespace parakeet
         this->intensity = intensity;
     }
 
-    double PointPolar::getRange() const
-    {
-        return getRange_mm();
-    }
-
     double PointPolar::getRange_mm() const
     {
         return range_mm;
-    }
-
-    double PointPolar::getAngleInDegrees() const
-    {
-        return getAngle_deg();
     }
 
     double PointPolar::getAngle_deg() const

--- a/src/parakeet/PointXY.cpp
+++ b/src/parakeet/PointXY.cpp
@@ -25,16 +25,6 @@ namespace parakeet
         return getY_mm();
     }
 
-    double PointXY::getX_mm() const
-    {
-        return x_mm;
-    }
-
-    double PointXY::getY_mm() const
-    {
-        return y_mm;
-    }
-
     std::uint16_t PointXY::getIntensity() const
     {
         return intensity;


### PR DESCRIPTION
- Removed deprecated functions getRange, and getAngleInDegrees from PointPolar
- Removed deprecated functions getX, and getY from PointXY