### PR TITLE
PRKT-83 Version Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added sensor starting angle and spin rotation to the documentation
 - Added the option to convert from ScanDataXY to ScanDataPolar
+- Added a deprecation macro
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
 - Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created
+- Changed Windows and Linux if defines to be more consistent
 - Modified SimpleExample CMake to find the latest version of parakeet-sdk which can be found
-
-## [1.1.0] - 2021-06-21
-### Added
-- Deprecation macro
-
-### Modified
-- Properly label units of measure on variables
-- Windows and Linux if defines to be more consistent
+- Properly labeled units of measure on variables
 
 ## [1.0.1] - 2021-06-09
 ### Modified


### PR DESCRIPTION
Version 1.1.0 was a step on the way to 2.0.0, and therefore its changes should be with 2.0.0.