### PR TITLE
2.0.0 Release

### DIFF
--- a/.github/workflows/add_copyright_information.yaml
+++ b/.github/workflows/add_copyright_information.yaml
@@ -1,30 +1,30 @@
-name: Add Copyright Information Action
+name: Run Copyright Information Action
+
 on: [push]
+
+env:
+  DEVTOOLS_REPO: MechaSpin/parakeet-devtools
+  DEVTOOLS_REPO_BRANCH: main
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.DEVTOOLS_ACCESS_TOKEN }}
+
 jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
-        with:
-         path: parakeet
-      - name: Clone python script repo
-        uses: actions/checkout@v2
-        with:
-         repository: 'MechaSpin/parakeet-devtools'
-         path: 'parakeet-devtools'
-         token: ${{ secrets.DEVTOOLS_ACCESS_TOKEN }}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: execute copyright python script
-        run: |
-          python ./parakeet-devtools/parakeet_copyright.py
-      - name: Push changes to git
-        run: |
-          cd parakeet/
-          git config --global user.name 'CopyrightGitHubAction'
-          git config --global user.email 'build@mechaspin.com'
-          git commit -am "Add Copyright Information" || exit 0
-          git push
+          python-version: '3.x'
+      - name: Clone active repository/branch
+        uses: actions/checkout@v2
+        with:
+         path: parakeet
+      - name: Clone devtools repository
+        uses: actions/checkout@v2
+        with:
+         repository: ${{ env.DEVTOOLS_REPO }}
+         ref: ${{ env.DEVTOOLS_REPO_BRANCH }}
+         path: 'parakeet-devtools'
+         token: ${{ env.PERSONAL_ACCESS_TOKEN }}
+      - name: Run Copyright Action
+        uses: ./parakeet-devtools/actions/copyright_action/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - 2021-06-28
+## [2.0.0] - In-Development
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
+- Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created
 
 ## [1.1.0] - 2021-06-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed Windows and Linux if defines to be more consistent
 - Modified SimpleExample CMake to find the latest version of parakeet-sdk which can be found
 - Properly labeled units of measure on variables
+- Updated copyright action to call the action from inside the parakeet-devtools repo
 
 ## [1.0.1] - 2021-06-09
 ### Modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2021-06-28
+### Modified
+- Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
+
 ## [1.1.0] - 2021-06-21
 ### Added
 - Deprecation macro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0] - In-Development
+### Added
+- Added sensor starting angle and spin rotation to the documentation
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
 - Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added sensor starting angle and spin rotation to the documentation
 - Added the option to convert from ScanDataXY to ScanDataPolar
+- Added a deprecation macro
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
 - Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created
+- Changed Windows and Linux if defines to be more consistent
 - Modified SimpleExample CMake to find the latest version of parakeet-sdk which can be found
-
-## [1.1.0] - 2021-06-21
-### Added
-- Deprecation macro
-
-### Modified
-- Properly label units of measure on variables
-- Windows and Linux if defines to be more consistent
+- Properly labeled units of measure on variables
 
 ## [1.0.1] - 2021-06-09
 ### Modified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0] - In-Development
 ### Added
 - Added sensor starting angle and spin rotation to the documentation
+- Added the option to convert from ScanDataXY to ScanDataPolar
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
 - Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - In-Development
+## [2.0.0] - 2021-07-12
 ### Added
 - Added sensor starting angle and spin rotation to the documentation
 - Added the option to convert from ScanDataXY to ScanDataPolar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
 - Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created
+- Modified SimpleExample CMake to find the latest version of parakeet-sdk which can be found
 
 ## [1.1.0] - 2021-06-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a deprecation macro
 ### Modified
 - Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
-- Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifys when the first point was created
+- [BREAKING] Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifies when the first point was created
 - Changed Windows and Linux if defines to be more consistent
 - Modified SimpleExample CMake to find the latest version of parakeet-sdk which can be found
 - Properly labeled units of measure on variables
 - Updated copyright action to call the action from inside the parakeet-devtools repo
+### Deprecated
+- Deprecated method PointPolar.getRange(), use PointPolar.getRange_mm()
+- Deprecated method PointPolar.getAngleInDegrees(), use PointPolar.getAngle_deg()
+- Deprecated method Driver.connect requiring all sensor settings. Replaced with Driver.connect which takes in a SensorConfiguration object which holds all sensor settings
 
 ## [1.0.1] - 2021-06-09
 ### Modified
-- Changed documentation to more clearly state the need for the UART to USB Driver.
+- Changed documentation to more clearly state the need for the UART to USB Driver
 
 ## [1.0.0] - 2021-06-07
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(Parakeet VERSION 1.1.0)
+project(Parakeet VERSION 1.2.0)
 
 set (PROJECT_VERSION_STRING ${PROJECT_NAME}-${PROJECT_VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.5)
 project(Parakeet VERSION 2.0.0)
 
 set (PROJECT_VERSION_STRING ${PROJECT_NAME}-${PROJECT_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,8 @@ include(GNUInstallDirs)
 
 find_package(Threads REQUIRED)
 
-add_library (${PROJECT_NAME}
-	${PARAKEET_SOURCE} ${PARAKEET_HEADER}
-)
+add_library(${PROJECT_NAME} ${PARAKEET_SOURCE} ${PARAKEET_HEADER})
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 if(WIN32)
 	set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "d")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ set(PARAKEET_HEADER
 	${PARAKEET_HEADER_ROOT}/ScanDataXY.h
 	${PARAKEET_HEADER_ROOT}/SerialPort.h
 	${PARAKEET_HEADER_ROOT}/util.h
+	${PARAKEET_HEADER_ROOT}/exceptions/NotConnectedToSensorException.h
+	${PARAKEET_HEADER_ROOT}/exceptions/UnableToDetermineBaudRateException.h
+	${PARAKEET_HEADER_ROOT}/exceptions/UnableToOpenPortException.h
+	${PARAKEET_HEADER_ROOT}/internal/SensorResponse.h
+	${PARAKEET_HEADER_ROOT}/internal/SensorResponseParser.h
 	${PARAKEET_HEADER_ROOT}/internal/SerialPortHelper.h
 )
 
@@ -29,6 +34,11 @@ set(PARAKEET_SOURCE
 	${PARAKEET_SOURCE_ROOT}/ScanDataXY.cpp
 	${PARAKEET_SOURCE_ROOT}/SerialPort.cpp
 	${PARAKEET_SOURCE_ROOT}/util.cpp
+	${PARAKEET_SOURCE_ROOT}/exceptions/NotConnectedToSensorException.cpp
+	${PARAKEET_SOURCE_ROOT}/exceptions/UnableToDetermineBaudRateException.cpp
+	${PARAKEET_SOURCE_ROOT}/exceptions/UnableToOpenPortException.cpp
+	${PARAKEET_SOURCE_ROOT}/internal/SensorResponse.cpp
+	${PARAKEET_SOURCE_ROOT}/internal/SensorResponseParser.cpp
 	${PARAKEET_SOURCE_ROOT}/internal/SerialPortHelper.cpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project(Parakeet VERSION 1.2.0)
+project(Parakeet VERSION 2.0.0)
 
 set (PROJECT_VERSION_STRING ${PROJECT_NAME}-${PROJECT_VERSION})
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Parakeet-SDK
 
-Driver library for the Parakeet Pro LiDAR Sensor.
+Driver library for the Parakeet Pro LiDAR sensor.
 
 Documentation for building and installing the library can be found [here](docs/Building%20and%20Installing.md).
 
-## Windows Requirements
+## Additional information
 
 The CP210x USB to UART Bridge connector needs a specific driver installed to be used on Windows. You can find the latest driver [here](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers).
+
+The Parakeet-Pro LiDAR sensor has its starting angle of 0 in the center of the device, on the opposite side of the serial port. The device spins clockwise.
 
 ## Test Apps
 

--- a/examples/SimpleExample/CMakeLists.txt
+++ b/examples/SimpleExample/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.10)
 project(SimpleExample VERSION 1.0.0)
 
+set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 find_package(Parakeet REQUIRED)
 
 add_executable (${PROJECT_NAME} main.cpp)

--- a/examples/SimpleExample/main.cpp
+++ b/examples/SimpleExample/main.cpp
@@ -7,7 +7,7 @@
 #include <parakeet/Driver.h>
 #include <parakeet/util.h>
 
-const char versionNumber[] = "1.0.0";
+const char versionNumber[] = "1.1.0";
 
 std::shared_ptr<mechaspin::parakeet::PointPolar> minPoint;
 std::shared_ptr<mechaspin::parakeet::PointPolar> maxPoint;
@@ -54,33 +54,11 @@ void printOptionsMenu()
     std::cout << "**********************" << std::endl;
 }
 
-int main(int argc, char* argv[])
+void startAndRunSensor(const mechaspin::parakeet::Driver::SensorConfiguration& sensorConfiguration)
 {
-    if (argc != 3)
-    {
-        std::cout
-            << "Start application with parameters: {COM_PORT BAUDRATE}. ie: {COM4 500000}" << std::endl 
-            << "Specify a Baud Rate of 0 to automatically detect the baud rate" << std::endl;
-        return -1;
-    }
-
-    std::cout << "Starting Parakeet SimpleExample v" << versionNumber << std::endl;
-
     mechaspin::parakeet::Driver parakeetSensorDriver;
 
-    std::string comPort = argv[1];
-    mechaspin::parakeet::BaudRate baudRate(atoi(argv[2]));
-    bool useDataSmoothing = false;
-    bool useDragPointRemoval = false;
-    bool intensity = true;
-    mechaspin::parakeet::Driver::ScanningFrequency startingScanFrequency_Hz = mechaspin::parakeet::Driver::ScanningFrequency::Frequency_10Hz;
-
-    std::cout << "Attempting connection to sensor." << std::endl;
-    if(!parakeetSensorDriver.connect(comPort, baudRate, intensity, startingScanFrequency_Hz, useDataSmoothing, useDragPointRemoval))
-    {
-        std::cout << "Unable to connect to " << comPort << ", check to ensure that is the proper COM Port and that the unit is plugged in." << std::endl;
-        return -2;
-    }
+    parakeetSensorDriver.connect(sensorConfiguration);
 
     parakeetSensorDriver.registerScanCallback(onScanComplete);
 
@@ -151,6 +129,36 @@ int main(int argc, char* argv[])
         }
 
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc != 3)
+    {
+        std::cout
+            << "Start application with parameters: {COM_PORT BAUDRATE}. ie: {COM4 500000}" << std::endl 
+            << "Specify a Baud Rate of 0 to automatically detect the baud rate" << std::endl;
+        return -1;
+    }
+
+    std::cout << "Starting Parakeet SimpleExample v" << versionNumber << std::endl;
+
+    mechaspin::parakeet::Driver::SensorConfiguration sensorConfiguration;
+    sensorConfiguration.comPort = argv[1];
+    sensorConfiguration.baudRate = mechaspin::parakeet::BaudRate(atoi(argv[2]));
+    sensorConfiguration.dataSmoothing = false;
+    sensorConfiguration.dragPointRemoval = false;
+    sensorConfiguration.intensity = true;
+    sensorConfiguration.scanningFrequency_Hz = mechaspin::parakeet::Driver::ScanningFrequency::Frequency_10Hz;
+
+    try
+    {
+        startAndRunSensor(sensorConfiguration);
+    }
+    catch (const std::runtime_error& error)
+    {
+        std::cout << "The following exception occured when running the parakeet driver: " << error.what() << std::endl;
     }
 
     return 0;

--- a/include/parakeet/BaudRate.h
+++ b/include/parakeet/BaudRate.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_BAUDRATE_H
+#define PARAKEET_BAUDRATE_H
 
 #include <string>
 #include <vector>
@@ -20,7 +21,7 @@ class BaudRate
         /// \returns A BaudRate object which holds the baud rate value given through the param.
         constexpr BaudRate(int value) : value(value)
         {
-
+            
         }
 
         /// \brief Get the baud rate value as a string
@@ -56,3 +57,5 @@ namespace BaudRates
 }
 }
 }
+
+#endif

--- a/include/parakeet/Driver.h
+++ b/include/parakeet/Driver.h
@@ -141,6 +141,7 @@ class Driver
         std::chrono::milliseconds interfaceThreadStartTime;
         int interfaceThreadFrameCount = 0;
 
+        std::chrono::time_point<std::chrono::system_clock> timeOfFirstPoint;
         std::vector<PointPolar> pointHoldingList;
         std::function<void(const ScanDataPolar&)> scanCallbackFunction = nullptr;
 

--- a/include/parakeet/PointPolar.h
+++ b/include/parakeet/PointPolar.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_POINTPOLAR_H
+#define PARAKEET_POINTPOLAR_H
 
 #include <cstdint>
 #include "macros.h"
@@ -49,3 +50,5 @@ class PointPolar
 };
 }
 }
+
+#endif

--- a/include/parakeet/PointXY.h
+++ b/include/parakeet/PointXY.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_POINTXY_H
+#define PARAKEET_POINTXY_H
 
 #include <cstdint>
 #include "macros.h"
@@ -50,3 +51,5 @@ class PointXY
 };
 }
 }
+
+#endif

--- a/include/parakeet/ScanDataPolar.h
+++ b/include/parakeet/ScanDataPolar.h
@@ -18,15 +18,14 @@ class ScanDataPolar
     public:
         /// \brief Create a ScanDataPolar which is responsible for holding on to a list of PointPolars
         /// \param[in] pointPolarList - A vector containing PointPolar(s)
-        /// \returns A ScanDataPolar object which holds the information given through the param, and generates a timestamp.
-        ScanDataPolar(const std::vector<PointPolar>& pointPolarList);
+        /// \param[in] timestamp - A time point which holds the time the first point was received
+        /// \returns A ScanDataPolar object which holds a vector of PointPolar(s) and a timestamp
+        ScanDataPolar(const std::vector<PointPolar>& pointPolarList, const std::chrono::time_point<std::chrono::system_clock>& timestamp);
         
         /// \brief Returns the vector of points this object is holding onto
-        /// \returns Vector of points this object is holding onto
         const std::vector<PointPolar>& getPoints() const;
         
-        /// \brief Returns the timestamp of this objects creation
-        /// \returns Timestamp of this objects creation
+        /// \brief Returns the timestamp which signals when the first point was received
         const std::chrono::time_point<std::chrono::system_clock>& getTimestamp() const;
 
     private:

--- a/include/parakeet/ScanDataPolar.h
+++ b/include/parakeet/ScanDataPolar.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_SCANDATAPOLAR_H
+#define PARAKEET_SCANDATAPOLAR_H
 
 #include "PointPolar.h"
 
@@ -17,10 +18,10 @@ class ScanDataPolar
 {
     public:
         /// \brief Create a ScanDataPolar which is responsible for holding on to a list of PointPolars
-        /// \param[in] pointPolarList - A vector containing PointPolar(s)
-        /// \param[in] timestamp - A time point which holds the time the first point was received
+        /// \param[in] vectorOfPolarPoints - A vector containing PointPolar(s)
+        /// \param[in] timestampOfFirstPoint - A time point which holds the time the first point was received
         /// \returns A ScanDataPolar object which holds a vector of PointPolar(s) and a timestamp
-        ScanDataPolar(const std::vector<PointPolar>& pointPolarList, const std::chrono::time_point<std::chrono::system_clock>& timestamp);
+        ScanDataPolar(const std::vector<PointPolar>& vectorOfPolarPoints, const std::chrono::time_point<std::chrono::system_clock>& timestampOfFirstPoint);
         
         /// \brief Returns the vector of points this object is holding onto
         const std::vector<PointPolar>& getPoints() const;
@@ -29,8 +30,10 @@ class ScanDataPolar
         const std::chrono::time_point<std::chrono::system_clock>& getTimestamp() const;
 
     private:
-        std::vector<PointPolar> points_mm;
-        std::chrono::time_point<std::chrono::system_clock> timestamp;
+        std::vector<PointPolar> vectorOfPolarPoints;
+        std::chrono::time_point<std::chrono::system_clock> timestampOfFirstPoint;
 };
 }
 }
+
+#endif

--- a/include/parakeet/ScanDataXY.h
+++ b/include/parakeet/ScanDataXY.h
@@ -18,15 +18,14 @@ class ScanDataXY
     public:
         /// \brief Create a ScanDataXY which is responsible for holding on to a list of PointXYs
         /// \param[in] pointPolarList - A vector containing PointXY(s)
-        /// \returns A ScanDataXY object which holds the information given through the param, and generates a timestamp.
-        ScanDataXY(const std::vector<PointXY>& pointXYList);
+        /// \param[in] timestamp - A time point which holds the time the first point was received
+        /// \returns A ScanDataXY object which holds a vector of PointXY(s) and a timestamp
+        ScanDataXY(const std::vector<PointXY>& pointXYList, const std::chrono::time_point<std::chrono::system_clock>& timestamp);
         
         /// \brief Returns the vector of points this object is holding onto
-        /// \returns Vector of points this object is holding onto
         const std::vector<PointXY>& getPoints() const;
         
-        /// \brief Returns the timestamp of this objects creation
-        /// \returns Timestamp of this objects creation
+        /// \brief Returns the timestamp which signals when the first point was received
         const std::chrono::time_point<std::chrono::system_clock>& getTimestamp() const;
 
     private:

--- a/include/parakeet/ScanDataXY.h
+++ b/include/parakeet/ScanDataXY.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_SCANDATAXY_H
+#define PARAKEET_SCANDATAXY_H
 
 #include "PointXY.h"
 
@@ -17,10 +18,10 @@ class ScanDataXY
 {
     public:
         /// \brief Create a ScanDataXY which is responsible for holding on to a list of PointXYs
-        /// \param[in] pointPolarList - A vector containing PointXY(s)
-        /// \param[in] timestamp - A time point which holds the time the first point was received
+        /// \param[in] vectorOfCartesianPoints - A vector containing PointXY(s)
+        /// \param[in] timestampOfFirstPoint - A time point which holds the time the first point was received
         /// \returns A ScanDataXY object which holds a vector of PointXY(s) and a timestamp
-        ScanDataXY(const std::vector<PointXY>& pointXYList, const std::chrono::time_point<std::chrono::system_clock>& timestamp);
+        ScanDataXY(const std::vector<PointXY>& vectorOfCartesianPoints, const std::chrono::time_point<std::chrono::system_clock>& timestampOfFirstPoint);
         
         /// \brief Returns the vector of points this object is holding onto
         const std::vector<PointXY>& getPoints() const;
@@ -29,8 +30,10 @@ class ScanDataXY
         const std::chrono::time_point<std::chrono::system_clock>& getTimestamp() const;
 
     private:
-        std::vector<PointXY> points_mm;
-        std::chrono::time_point<std::chrono::system_clock> timestamp;
+        std::vector<PointXY> vectorOfCartesianPoints;
+        std::chrono::time_point<std::chrono::system_clock> timestampOfFirstPoint;
 };
 }
 }
+
+#endif

--- a/include/parakeet/SerialPort.h
+++ b/include/parakeet/SerialPort.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_SERIALPORT_H
+#define PARAKEET_SERIALPORT_H
 
 #include <string>
 #include <iostream>
@@ -40,17 +41,16 @@ class SerialPort
 
         /// \brief Opens a connection to the serial port to be read from and written to
         /// \param[in] name - The OS level name for the serial port (COM3 | /dev/ttyUSB0)
-        /// \param[in] speed - The baud rate the serial port should be opened with
+        /// \param[in] baudRate - The baud rate the serial port should be opened with
         /// \returns The success state of the open operation
-        bool open(const char* name, const BaudRate& speed);
+        bool open(const char* name, const BaudRate& baudRate);
 
         /// \brief Closes the serial port connection if open
         void close();
 
-
         /// \brief Closes from an existing serial port connection, and re-opens it under a new baud rate
-        /// \param[in] speed - The new baud rate value to be used
-        void changeBaudRate(const BaudRate& speed);
+        /// \param[in] baudRate - The new baud rate value to be used
+        void changeBaudRate(const BaudRate& baudRate);
 
         /// \brief Check if the serial port is connected
         /// \returns A boolean containing the connection state
@@ -66,3 +66,5 @@ class SerialPort
 };
 }
 }
+
+#endif

--- a/include/parakeet/exceptions/NotConnectedToSensorException.h
+++ b/include/parakeet/exceptions/NotConnectedToSensorException.h
@@ -1,0 +1,25 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#ifndef PARAKEET_NOTCONNECTEDTOSENSOREXCEPTION_H
+#define PARAKEET_NOTCONNECTEDTOSENSOREXCEPTION_H
+
+#include <stdexcept>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace exceptions
+{
+class NotConnectedToSensorException : public std::runtime_error
+{
+    public:
+        NotConnectedToSensorException();
+};
+}
+}
+}
+
+#endif

--- a/include/parakeet/exceptions/UnableToDetermineBaudRateException.h
+++ b/include/parakeet/exceptions/UnableToDetermineBaudRateException.h
@@ -1,0 +1,25 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#ifndef PARAKEET_UNABLETODETERMINEBAUDRATEEXCEPTION_H
+#define PARAKEET_UNABLETODETERMINEBAUDRATEEXCEPTION_H
+
+#include <stdexcept>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace exceptions
+{
+class UnableToDetermineBaudRateException : public std::runtime_error
+{
+    public:
+        UnableToDetermineBaudRateException();
+};
+}
+}
+}
+
+#endif

--- a/include/parakeet/exceptions/UnableToOpenPortException.h
+++ b/include/parakeet/exceptions/UnableToOpenPortException.h
@@ -1,0 +1,25 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#ifndef PARAKEET_UNABLETOOPENPORTEXCEPTION_H
+#define PARAKEET_UNABLETOOPENPORTEXCEPTION_H
+
+#include <stdexcept>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace exceptions
+{
+class UnableToOpenPortException : public std::runtime_error
+{
+    public:
+        UnableToOpenPortException();
+};
+}
+}
+}
+
+#endif

--- a/include/parakeet/internal/SensorResponse.h
+++ b/include/parakeet/internal/SensorResponse.h
@@ -1,0 +1,46 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#ifndef PARAKEET_SENSORRESPONSE_H
+#define PARAKEET_SENSORRESPONSE_H
+
+#include <string>
+#include <vector>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace internal
+{
+class SensorResponse
+{
+    public:
+        enum MessageType
+        {
+            STOP,
+            START,
+            INTENSITY,
+            SPEED,
+            BAUDRATE,
+            DATASMOOTHING,
+            DRAGPOINTREMOVAL,
+            NA
+        };
+
+        SensorResponse(MessageType messageType, const std::string& message);
+        SensorResponse(MessageType messageType, const std::vector<std::string>& messages);
+
+        MessageType getMessageType() const;
+
+        const std::vector<std::string>& getResponses() const;
+    private:
+        std::vector<std::string> possibleResponses;
+        MessageType messageType;
+};
+}
+}
+}
+
+#endif

--- a/include/parakeet/internal/SensorResponseParser.h
+++ b/include/parakeet/internal/SensorResponseParser.h
@@ -1,0 +1,31 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#ifndef PARAKEET_SENSORRESPONSEPARSER_H
+#define PARAKEET_SENSORRESPONSEPARSER_H
+
+#include <parakeet/internal/SensorResponse.h>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace internal
+{
+class SensorResponseParser
+{
+    public:
+        SensorResponseParser();
+        SensorResponse getSensorResponseFromMessage(const std::string& message);
+
+    private:
+        bool doesMessageMatchResponse(const std::string& message, const SensorResponse& response);
+
+        std::vector<SensorResponse> allResponses;
+};
+}
+}
+}
+
+#endif

--- a/include/parakeet/internal/SerialPortHelper.h
+++ b/include/parakeet/internal/SerialPortHelper.h
@@ -2,9 +2,16 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_SERIALPORTHELPER
+#define PARAKEET_SERIALPORTHELPER
 
 #if defined(__linux) || defined(linux) || defined(__linux__)
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace internal
+{
 class SerialPortHelper
 {
     public:
@@ -13,4 +20,9 @@ class SerialPortHelper
         /// \param[in] baudRate - The baud rate the serial port should be connected with
         static void setCustomBaudRate(int fileDescriptor, int baudRate);
 };
+}
+}
+}
+#endif
+
 #endif

--- a/include/parakeet/macros.h
+++ b/include/parakeet/macros.h
@@ -2,8 +2,13 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
+#ifndef MACROS_H
+#define MACROS_H
+
 #if defined(_WIN32)
     #define PARAKEET_DEPRECATED(func) __declspec(deprecated) func
 #elif defined(__linux) || defined(linux) || defined(__linux__)
     #define PARAKEET_DEPRECATED(func) func __attribute__ ((deprecated))
+#endif
+
 #endif

--- a/include/parakeet/util.h
+++ b/include/parakeet/util.h
@@ -30,6 +30,16 @@ class util
         /// \returns A PointXY object which holds the same position as the PointPolar param
         static PointXY transform(const PointPolar& polarPoint);
 
+        /// \brief Translates a ScanDataXY into a ScanDataPolar
+        /// \param[in] polarScanData - A ScanDataXY object containing a list of PointXYs to be converted
+        /// \returns A ScanDataPolar object containing a list of PointXY's which were obtained by converting the PointXYs from the param
+        static ScanDataPolar transform(const ScanDataXY& polarScanData);
+
+        /// \brief Translates a PointXY into a PointPolar
+        /// \param[in] polarPoint - A PointXY object to be converted
+        /// \returns A PointPolar object which holds the same position as the PointXY param
+        static PointPolar transform(const PointXY& polarPoint);
+
         template <typename T>
         static T degreesToRadians(T degrees)
         {
@@ -40,6 +50,13 @@ class util
         static T radiansToDegrees(T radians)
         {
             return radians * 180 / M_PI;
+        }
+
+    private:
+        template <typename T>
+        static T radiansToDegrees0To360(T radians)
+        {
+            return (radiansToDegrees(radians)) + (radians > 0 ? 0 : 360);
         }
 };
 }

--- a/include/parakeet/util.h
+++ b/include/parakeet/util.h
@@ -2,7 +2,8 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
+#ifndef PARAKEET_UTIL_H
+#define PARAKEET_UTIL_H
 
 #include "ScanDataPolar.h"
 #include "ScanDataXY.h"
@@ -31,14 +32,14 @@ class util
         static PointXY transform(const PointPolar& polarPoint);
 
         /// \brief Translates a ScanDataXY into a ScanDataPolar
-        /// \param[in] polarScanData - A ScanDataXY object containing a list of PointXYs to be converted
+        /// \param[in] cartesianScanData - A ScanDataXY object containing a list of PointXYs to be converted
         /// \returns A ScanDataPolar object containing a list of PointXY's which were obtained by converting the PointXYs from the param
-        static ScanDataPolar transform(const ScanDataXY& polarScanData);
+        static ScanDataPolar transform(const ScanDataXY& cartesianScanData);
 
         /// \brief Translates a PointXY into a PointPolar
-        /// \param[in] polarPoint - A PointXY object to be converted
+        /// \param[in] cartesianPoint - A PointXY object to be converted
         /// \returns A PointPolar object which holds the same position as the PointXY param
-        static PointPolar transform(const PointXY& polarPoint);
+        static PointPolar transform(const PointXY& cartesianPoint);
 
         template <typename T>
         static T degreesToRadians(T degrees)
@@ -61,3 +62,5 @@ class util
 };
 }
 }
+
+#endif

--- a/src/parakeet/Driver.cpp
+++ b/src/parakeet/Driver.cpp
@@ -189,11 +189,7 @@ namespace parakeet
 
     void Driver::enableDataSmoothing(bool enable)
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot modify data smoothing until connected." << std::endl;
-            return;
-        }
+        throwExceptionIfNotConnected();
 
         sendMessageWaitForResponseOrTimeout(internal::SensorResponse::DATASMOOTHING, enable ? CW_ENABLE_DATA_SMOOTHING : CW_DISABLE_DATA_SMOOTHING, std::chrono::milliseconds(250));
 

--- a/src/parakeet/Driver.cpp
+++ b/src/parakeet/Driver.cpp
@@ -380,6 +380,11 @@ namespace parakeet
 
     void Driver::OnData(ScanData* data)
     {
+        if(pointHoldingList.size() == 0)
+        {
+            timeOfFirstPoint = std::chrono::system_clock::now();
+        }
+
         double startAngle_deg = data->from / 10.0;
         double endAngle_deg = (static_cast<double>(data->from) + static_cast<double>(data->span)) / 10.0;
         double anglePerPoint_deg = (endAngle_deg - startAngle_deg) / data->count;
@@ -388,20 +393,20 @@ namespace parakeet
         //Create PointPolar for each data point
         for(int i = 0; i < data->count; i++)
         {
-            PointPolar p(data->dist[i], startAngle_deg + (anglePerPoint_deg * i), data->intensity[i]);
+            PointPolar pointPolar(data->dist[i], startAngle_deg + (anglePerPoint_deg * i), data->intensity[i]);
 
-            pointHoldingList.push_back(p);
+            pointHoldingList.push_back(pointPolar);
         }
 
         if(endAngle_deg + deviationFrom360_deg >= 360)
         {
             interfaceThreadFrameCount++;
 
-            ScanDataPolar sdp(pointHoldingList);
+            ScanDataPolar scanDataPolar(pointHoldingList, timeOfFirstPoint);
 
             if (scanCallbackFunction != nullptr)
             {
-                scanCallbackFunction(sdp);
+                scanCallbackFunction(scanDataPolar);
             }
 
             pointHoldingList.clear();

--- a/src/parakeet/Driver.cpp
+++ b/src/parakeet/Driver.cpp
@@ -4,135 +4,160 @@
 
 #include <parakeet/Driver.h>
 
+#include <parakeet/exceptions/NotConnectedToSensorException.h>
+#include <parakeet/exceptions/UnableToDetermineBaudRateException.h>
+#include <parakeet/exceptions/UnableToOpenPortException.h>
+
 namespace mechaspin
 {
 namespace parakeet
 {
-    const std::string Driver::CW_STOP_ROTATING = "LSTOPH";
-    const std::string Driver::CW_START_NORMALLY = "LSTARH";
-    const std::string Driver::CW_STOP_ROTATING_FIX_DIST = "LMEASH";
-    const std::string Driver::CW_RESET_AND_RESTART = "LRESTH";
-    const std::string Driver::CW_VERSION_NUMBER = "LVERSH";
+    const int MAX_NUMBER_OF_POINTS_FROM_SENSOR = 1000;  // Arbitrary size
+    const int MESSAGE_DATA_BUFFER_SIZE = 8192;          // Arbitrary size
 
-    const std::string Driver::CW_ENABLE_DATA_SMOOTHING = "LSSS1H";
-    const std::string Driver::CW_DISABLE_DATA_SMOOTHING = "LSSS0H";
-    const std::string Driver::CW_ENABLE_DRAG_POINT_REMOVAL = "LFFF1H";
-    const std::string Driver::CW_DISABLE_DRAG_POINT_REMOVAL = "LFFF0H";
+    struct Driver::ScanData
+    {
+        unsigned short from;
+        unsigned short span;
+        unsigned short count;
+        unsigned short reserved;
+        unsigned short dist[MAX_NUMBER_OF_POINTS_FROM_SENSOR];
+        unsigned char intensity[MAX_NUMBER_OF_POINTS_FROM_SENSOR];
+    };
 
-    const std::string Driver::SW_START_WITH_INTENSITY = "LOCONH";
-    const std::string Driver::SW_START_WITHOUT_INTENSITY = "LNCONH";
+    struct Driver::MessageData
+    {
+        int len;
+        unsigned char body[MESSAGE_DATA_BUFFER_SIZE];
+    };
 
-    const std::string Driver::SW_SET_SPEED_PREFIX = "LSRPM:";
-    const std::string Driver::SW_SET_SPEED_POSTFIX = "H";
-    const std::string Driver::SW_SET_SPEED(int speed)
+    const std::string CW_STOP_ROTATING = "LSTOPH";
+    const std::string CW_START_NORMALLY = "LSTARH";
+    const std::string CW_STOP_ROTATING_FIX_DIST = "LMEASH";
+    const std::string CW_RESET_AND_RESTART = "LRESTH";
+    const std::string CW_VERSION_NUMBER = "LVERSH";
+
+    const std::string CW_ENABLE_DATA_SMOOTHING = "LSSS1H";
+    const std::string CW_DISABLE_DATA_SMOOTHING = "LSSS0H";
+    const std::string CW_ENABLE_DRAG_POINT_REMOVAL = "LFFF1H";
+    const std::string CW_DISABLE_DRAG_POINT_REMOVAL = "LFFF0H";
+
+    const std::string SW_START_WITH_INTENSITY = "LOCONH";
+    const std::string SW_START_WITHOUT_INTENSITY = "LNCONH";
+
+    const std::string SW_SET_SPEED_PREFIX = "LSRPM:";
+    const std::string SW_SET_SPEED_POSTFIX = "H";
+
+    const std::string SW_SET_BIAS_PREFIX = "LSERR:";
+    const std::string SW_SET_BIAS_POSTFIX = "H";
+
+    const std::string SW_SET_BAUD_RATE_PREFIX = "LSBPS:";
+    const std::string SW_SET_BAUD_RATE_POSTFIX = "H";
+    
+    const std::string SW_SET_SPEED(int speed)
     {
         return SW_SET_SPEED_PREFIX + std::to_string(speed) + SW_SET_SPEED_POSTFIX;
     }
 
-    const std::string Driver::SW_SET_BIAS_PREFIX = "LSERR:";
-    const std::string Driver::SW_SET_BIAS_POSTFIX = "H";
-    const std::string Driver::SW_SET_BIAS(int bias)
-    {
-        return SW_SET_BIAS_PREFIX + std::to_string(bias) + SW_SET_BIAS_POSTFIX;
-    }
-
-    const std::string Driver::Driver::SW_SET_BAUD_RATE_PREFIX = "LSBPS:";
-    const std::string Driver::SW_SET_BAUD_RATE_POSTFIX = "H";
-    const std::string Driver::SW_SET_BAUD_RATE(int baudRate)
+    const std::string SW_SET_BAUD_RATE(int baudRate)
     {
         return SW_SET_BAUD_RATE_PREFIX + std::to_string(baudRate) + SW_SET_BAUD_RATE_POSTFIX;
+    }
+    
+    const std::string SW_SET_BIAS(int bias)
+    {
+        return SW_SET_BIAS_PREFIX + std::to_string(bias) + SW_SET_BIAS_POSTFIX;
     }
 
     Driver::~Driver()
     {
         close();
     }
+    
+    void Driver::connect(const SensorConfiguration& sensorConfiguration)
+    {
+        this->sensorConfiguration = sensorConfiguration;
+
+        if(sensorConfiguration.baudRate == BaudRates::Auto)
+        {
+            autoFindBaudRate();
+        }
+
+        open();
+    }
 
     bool Driver::connect(const std::string& comPort, BaudRate baudRate, bool intensity, ScanningFrequency scanningFrequency_Hz, bool dataSmoothing, bool dragPointRemoval)
     {
-        if(scanningFrequency_Hz == ScanningFrequency::NOT_INITIALIZED)
+        SensorConfiguration paramConfiguration(comPort, baudRate, intensity, scanningFrequency_Hz, dataSmoothing, dragPointRemoval);
+        
+        try
         {
-            throw std::runtime_error("Scanning Frequency must be intialized on connect");
+            connect(paramConfiguration);
+        }
+        catch (const std::runtime_error&)
+        {
             return false;
         }
-
-        g_withIntensity = intensity;
-        g_scanningFrequency_Hz = scanningFrequency_Hz;
-        g_withDataSmoothing = dataSmoothing;
-        g_withDragPointRemoval = dragPointRemoval;
-
-        if(baudRate == BaudRates::Auto)
-        {
-            return autoFindBaudRate(comPort, intensity, scanningFrequency_Hz, dataSmoothing, dragPointRemoval);
-        }
-
-        isAutoConnecting = false;
-
-        if (!serialPort.open(comPort.c_str(), baudRate))
-        {
-            std::cout << "Could not open port " << comPort << std::endl;
-            return false;
-        }
-
-        //There's no guarentee these will ever be recieved
-        serialPort.write(CW_STOP_ROTATING);
-
-        g_baudRate = baudRate;
 
         return true;
     }
 
-    bool Driver::autoFindBaudRate(const std::string& comPort, bool intensity, ScanningFrequency scanningFrequency_Hz, bool dataSmoothing, bool dragPointRemoval)
+    void Driver::open()
     {
-        isAutoConnecting = true;
+        if (serialPort.open(sensorConfiguration.comPort.c_str(), sensorConfiguration.baudRate))
+        {
+            serialPort.write(CW_STOP_ROTATING);
+        }
+        else
+        {
+            throw exceptions::UnableToOpenPortException();
+        }
+    }
 
+    void Driver::autoFindBaudRate()
+    {
         // Loop through all accepted baud rates
-        for (auto baudRate : mechaspin::parakeet::BaudRates::All)
+        for (BaudRate baudRate : BaudRates::All)
         {
             //Attempt connecting to the port
-            if (!serialPort.open(comPort.c_str(), baudRate.getValue()))
-            {
-                std::cout << "Could not open port " << comPort << std::endl;
-                return false;
-            }
+            this->sensorConfiguration.baudRate = baudRate;
+            
+            open();
 
             //start parsing data from the sensor
+            isAutoConnecting = true;
             start();
 
-            bool state = waitForMessage(LidarReturnMessage::STOP, CW_STOP_ROTATING, std::chrono::milliseconds(250));
+            bool state = sendMessageWaitForResponseOrTimeout(internal::SensorResponse::STOP, CW_STOP_ROTATING, std::chrono::milliseconds(500));
 
             stop();
             close();
+            isAutoConnecting = false;
 
-            if (state)
+            if(state)
             {
-                return connect(comPort, baudRate, intensity, scanningFrequency_Hz, dataSmoothing, dragPointRemoval);
+                return;
             }
         }
 
-        //failure to find the correct baud rate
-        return false;
+        throw exceptions::UnableToDetermineBaudRateException();
     }
 
     void Driver::start()
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot start until connected." << std::endl;
-            return;
-        }
+        throwExceptionIfNotConnected();
 
         runSerialInterfaceThread = true;
         interfaceThreadStartTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
         interfaceThreadFrameCount = 0;
         serialInterfaceThread = std::thread([&] { this->serialInterfaceThreadFunction(); });
 
-        waitForMessage(LidarReturnMessage::START, CW_START_NORMALLY, std::chrono::milliseconds(1000));
+        sendMessageWaitForResponseOrTimeout(internal::SensorResponse::START, CW_START_NORMALLY, std::chrono::milliseconds(1000));
 
-        enableIntensityData(g_withIntensity);
-        enableDataSmoothing(g_withDataSmoothing);
-        enableRemoveDragPoint(g_withDragPointRemoval);
-        setScanningFrequency_Hz(g_scanningFrequency_Hz);
+        enableIntensityData(sensorConfiguration.intensity);
+        enableDataSmoothing(sensorConfiguration.dataSmoothing);
+        enableRemoveDragPoint(sensorConfiguration.dragPointRemoval);
+        setScanningFrequency_Hz(sensorConfiguration.scanningFrequency_Hz);
     }
 
     void Driver::stop()
@@ -170,123 +195,93 @@ namespace parakeet
             return;
         }
 
-        waitForMessage(LidarReturnMessage::DATASMOOTHING, enable ? CW_ENABLE_DATA_SMOOTHING : CW_DISABLE_DATA_SMOOTHING, std::chrono::milliseconds(250));
+        sendMessageWaitForResponseOrTimeout(internal::SensorResponse::DATASMOOTHING, enable ? CW_ENABLE_DATA_SMOOTHING : CW_DISABLE_DATA_SMOOTHING, std::chrono::milliseconds(250));
 
-        g_withDataSmoothing = enable;
+        sensorConfiguration.dataSmoothing = enable;
     }
 
     void Driver::enableRemoveDragPoint(bool enable)
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot modify remove drag point until connected." << std::endl;
-            return;
-        }
+        throwExceptionIfNotConnected();
 
-        waitForMessage(LidarReturnMessage::DRAGPOINTREMOVAL, enable ? CW_ENABLE_DRAG_POINT_REMOVAL : CW_DISABLE_DRAG_POINT_REMOVAL, std::chrono::milliseconds(250));
+        sendMessageWaitForResponseOrTimeout(internal::SensorResponse::DRAGPOINTREMOVAL, enable ? CW_ENABLE_DRAG_POINT_REMOVAL : CW_DISABLE_DRAG_POINT_REMOVAL, std::chrono::milliseconds(250));
 
-        g_withDragPointRemoval = enable;
+        sensorConfiguration.dragPointRemoval = enable;
     }
 
     void Driver::enableIntensityData(bool enable)
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot modify intensity data status until connected." << std::endl;
-            return;
-        }
+        throwExceptionIfNotConnected();
 
-        waitForMessage(LidarReturnMessage::INTENSITY, enable ? SW_START_WITH_INTENSITY : SW_START_WITHOUT_INTENSITY, std::chrono::milliseconds(250));
+        sendMessageWaitForResponseOrTimeout(internal::SensorResponse::INTENSITY, enable ? SW_START_WITH_INTENSITY : SW_START_WITHOUT_INTENSITY, std::chrono::milliseconds(250));
 
-        g_withIntensity = enable;
+        sensorConfiguration.intensity = enable;
     }
 
     void Driver::setScanningFrequency_Hz(ScanningFrequency Hz)
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot modify scanning frequency until connected." << std::endl;
-            return;
-        }
+        throwExceptionIfNotConnected();
 
-        if(Hz == ScanningFrequency::NOT_INITIALIZED)
-        {
-            throw std::runtime_error("Can not set scanning frequency to NOT_INITIALIZED");
-        }
+        sendMessageWaitForResponseOrTimeout(internal::SensorResponse::SPEED, SW_SET_SPEED(Hz * 60), std::chrono::milliseconds(250));
 
-        waitForMessage(LidarReturnMessage::SPEED, SW_SET_SPEED(Hz * 60), std::chrono::milliseconds(250));
-
-        g_scanningFrequency_Hz = Hz;
+        sensorConfiguration.scanningFrequency_Hz = Hz;
     }
 
     BaudRate Driver::getBaudRate()
     {
-        return g_baudRate;
+        return sensorConfiguration.baudRate;
     }
 
     void Driver::setBaudRate(BaudRate baudRate)
     {
-        if (!serialPort.isConnected())
+        throwExceptionIfNotConnected();
+
+        sendMessageWaitForResponseOrTimeout(internal::SensorResponse::STOP, CW_STOP_ROTATING, std::chrono::milliseconds(200));
+
+        sendMessageWaitForResponseOrTimeout(internal::SensorResponse::BAUDRATE, SW_SET_BAUD_RATE(baudRate.getValue()), std::chrono::milliseconds(0));
+
+        if(runSerialInterfaceThread)
         {
-            std::cout << "Cannot set baud rate of device until connected." << std::endl;
-            return;
+            stop();
+
+            serialPort.changeBaudRate(baudRate);
+
+            start();
+        }
+        else
+        {
+            serialPort.changeBaudRate(baudRate);
         }
 
-        waitForMessage(LidarReturnMessage::STOP, CW_STOP_ROTATING, std::chrono::milliseconds(200));
-
-        waitForMessage(LidarReturnMessage::BAUDRATE, SW_SET_BAUD_RATE(baudRate.getValue()), std::chrono::milliseconds(0));
-
-        stop();
-
-        serialPort.changeBaudRate(baudRate);
-
-        start();
-
-        g_baudRate = baudRate;
+        sensorConfiguration.baudRate = baudRate;
     }
 
     bool Driver::isDataSmoothingEnabled()
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot get the value for data smoothing until connected." << std::endl;
-            return false;
-        }
+        throwExceptionIfNotConnected();
 
-        return g_withDataSmoothing;
+        return sensorConfiguration.dataSmoothing;
     }
 
     bool Driver::isDragPointRemovalEnabled()
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot get the value for drag point removal until connected." << std::endl;
-            return false;
-        }
+        throwExceptionIfNotConnected();
 
-        return g_withDragPointRemoval;
+        return sensorConfiguration.dragPointRemoval;
     }
 
     bool Driver::isIntensityDataEnabled()
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot get the value for intensity data until connected." << std::endl;
-            return false;
-        }
+        throwExceptionIfNotConnected();
 
-        return g_withIntensity;
+        return sensorConfiguration.intensity;
     }
 
     Driver::ScanningFrequency Driver::getScanningFrequency_Hz()
     {
-        if (!serialPort.isConnected())
-        {
-            std::cout << "Cannot get the value for scanning frequency until connected." << std::endl;
-            return NOT_INITIALIZED;
-        }
+        throwExceptionIfNotConnected();
 
-        return g_scanningFrequency_Hz;
+        return sensorConfiguration.scanningFrequency_Hz;
     }
 
     double Driver::getScanRate_Hz()
@@ -305,8 +300,7 @@ namespace parakeet
 
     void Driver::serialInterfaceThreadFunction()
     {
-        int buf_size = 8 * 1024;
-        unsigned char* line = new unsigned char[buf_size];
+        unsigned char* line = new unsigned char[MESSAGE_DATA_BUFFER_SIZE];
         int len = 0;
 
         while (runSerialInterfaceThread)
@@ -317,7 +311,7 @@ namespace parakeet
                 continue;
             }
 
-            int charsRead = serialPort.read(line, len, buf_size);
+            int charsRead = serialPort.read(line, len, MESSAGE_DATA_BUFFER_SIZE);
 
             if (charsRead == 0)
             {
@@ -326,7 +320,7 @@ namespace parakeet
 
             len += charsRead;
 
-            int nl = Parse(len, line);
+            int nl = parseSensorDataFromBuffer(len, line);
 
             for (int i = nl; i<len; i++)
             {
@@ -336,64 +330,36 @@ namespace parakeet
         }
     }
 
-    void Driver::OnMsg(CommandData* msg)
+    void Driver::onMessageDataReceived(MessageData* message)
     {
-        std::string stringForm(reinterpret_cast<char*>(msg->body), msg->len);
+        std::string messageAsString(reinterpret_cast<char*>(message->body), message->len);
 
-        if (stringForm.rfind("LiDAR STOP") != std::string::npos)
+        internal::SensorResponse sensorResponse = sensorResponseParser.getSensorResponseFromMessage(messageAsString);
+
+        if(sensorResponse.getMessageType() != internal::SensorResponse::NA)
         {
-            sensorMessages[LidarReturnMessage::STOP] = true;
+            sensorReturnMessageState[sensorResponse.getMessageType()] = true;
         }
 
-        if (stringForm.rfind("LiDAR START") != std::string::npos)
-        {
-            sensorMessages[LidarReturnMessage::START] = true;
-        }
-
-        if (stringForm.rfind("Error: OK") != std::string::npos)
-        {
-            sensorMessages[LidarReturnMessage::BAUDRATE] = true;
-        }
-
-        if (stringForm.rfind("LiDAR CONFID") != std::string::npos || stringForm.rfind("LiDAR NO CONFID") != std::string::npos)
-        {
-            sensorMessages[LidarReturnMessage::INTENSITY] = true;
-        }
-
-        if (stringForm.rfind("LiDAR set smooth ok") != std::string::npos)
-        {
-            sensorMessages[LidarReturnMessage::DATASMOOTHING] = true;
-        }
-
-        if (stringForm.rfind("LiDAR set filter ok") != std::string::npos)
-        {
-            sensorMessages[LidarReturnMessage::DRAGPOINTREMOVAL] = true;
-        }
-
-        if (stringForm.rfind("Set RPM: OK") != std::string::npos)
-        {
-            sensorMessages[LidarReturnMessage::SPEED] = true;
-        }
-
-        delete msg;
+        delete message;
     }
 
-    void Driver::OnData(ScanData* data)
+    void Driver::onScanDataReceived(ScanData* scanData)
     {
         if(pointHoldingList.size() == 0)
         {
             timeOfFirstPoint = std::chrono::system_clock::now();
         }
 
-        double startAngle_deg = data->from / 10.0;
-        double endAngle_deg = (static_cast<double>(data->from) + static_cast<double>(data->span)) / 10.0;
-        double anglePerPoint_deg = (endAngle_deg - startAngle_deg) / data->count;
+        double startAngle_deg = scanData->from / 10.0;
+        double endAngle_deg = (static_cast<double>(scanData->from) + static_cast<double>(scanData->span)) / 10.0;
+        double anglePerPoint_deg = (endAngle_deg - startAngle_deg) / scanData->count;
         double deviationFrom360_deg = 1;
 
         //Create PointPolar for each data point
-        for(int i = 0; i < data->count; i++)
+        for(int i = 0; i < scanData->count; i++)
         {
-            PointPolar pointPolar(data->dist[i], startAngle_deg + (anglePerPoint_deg * i), data->intensity[i]);
+            PointPolar pointPolar(scanData->dist[i], startAngle_deg + (anglePerPoint_deg * i), scanData->intensity[i]);
 
             pointHoldingList.push_back(pointPolar);
         }
@@ -412,13 +378,13 @@ namespace parakeet
             pointHoldingList.clear();
         }
 
-        delete data;
+        delete scanData;
     }
 
-    int Driver::Parse(int nl, unsigned char* buf)
+    int Driver::parseSensorDataFromBuffer(int length, unsigned char* buf)
     {
         int idx = 0, found = 0;
-        while (idx + 8 < nl)
+        while (idx + 8 < length)
         {
             if (buf[idx] == 'S' && buf[idx + 1] == 'T' && buf[idx + 6] == 'E' && buf[idx + 7] == 'D')
             {
@@ -434,18 +400,18 @@ namespace parakeet
 
         if (idx > 0)// && found == 0)
         {
-            CommandData* cmd = new CommandData;
+            MessageData* cmd = new MessageData;
             if (found)
             {
                 cmd->len = idx;
             }
             else
             {
-                cmd->len = nl;
+                cmd->len = length;
             }
             memcpy(cmd->body, buf, cmd->len);
 
-            OnMsg(cmd);
+            onMessageDataReceived(cmd);
         }
 
         while (found)
@@ -455,10 +421,10 @@ namespace parakeet
             memcpy(&cnt, buf + idx + 2, 2);
             memcpy(&start, buf + idx + 4, 2);
 
-            if (!g_withIntensity)
+            if (!sensorConfiguration.intensity)
             {
                 //2 Byte
-                if (idx + 8 + cnt * 2 > nl)
+                if (idx + 8 + cnt * 2 > length)
                 {
                     break;
                 }
@@ -480,7 +446,7 @@ namespace parakeet
 
                     sum += val;
 
-                    if (g_withIntensity)
+                    if (sensorConfiguration.intensity)
                     {
                         data->dist[i] = val & 0x1FFF;
                         data->intensity[i] = val >> 13;
@@ -497,7 +463,7 @@ namespace parakeet
                 unsigned short chk = lo | (hi << 8);
                 if (chk == sum)
                 {
-                    OnData(data);
+                    onScanDataReceived(data);
                 }
                 else if(!isAutoConnecting)
                 {
@@ -510,7 +476,7 @@ namespace parakeet
             else
             {
                 //3 Byte
-                if (idx + 8 + cnt * 3 > nl)
+                if (idx + 8 + cnt * 3 > length)
                 {
                     break;
                 }
@@ -544,7 +510,7 @@ namespace parakeet
                 unsigned short hi = pdata[cnt * 3+1];
                 if (((hi<<8) | lo) == sum)
                 {
-                    OnData(data);
+                    onScanDataReceived(data);
                 }
                 else if(!isAutoConnecting)
                 {
@@ -553,7 +519,7 @@ namespace parakeet
                 }
             }
 
-            if (idx + 8 > nl)
+            if (idx + 8 > length)
             {
                 break;
             }
@@ -571,16 +537,16 @@ namespace parakeet
         return idx;
     }
 
-    bool Driver::waitForMessage(Driver::LidarReturnMessage messageType, const std::string& message, std::chrono::milliseconds timeout)
+    bool Driver::sendMessageWaitForResponseOrTimeout(internal::SensorResponse::MessageType messageType, const std::string& message, std::chrono::milliseconds timeout)
     {
         auto startTime = std::chrono::system_clock::now();
 
-        sensorMessages[messageType] = false;
+        sensorReturnMessageState[messageType] = false;
 
         serialPort.write(message);
 
         int msCount = 0;
-        while (!sensorMessages[messageType]
+        while (!sensorReturnMessageState[messageType]
             && std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - startTime).count() < timeout.count())
         {
             if (msCount % 10)
@@ -592,7 +558,15 @@ namespace parakeet
             msCount++;
         }
 
-        return sensorMessages[messageType];
+        return sensorReturnMessageState[messageType];
+    }
+
+    void Driver::throwExceptionIfNotConnected()
+    {
+        if(!serialPort.isConnected())
+        {
+            throw exceptions::NotConnectedToSensorException();
+        }
     }
 }
 }

--- a/src/parakeet/ScanDataPolar.cpp
+++ b/src/parakeet/ScanDataPolar.cpp
@@ -8,9 +8,9 @@ namespace mechaspin
 {
 namespace parakeet
 {
-    ScanDataPolar::ScanDataPolar(const std::vector<PointPolar>& pointPolarList)
+    ScanDataPolar::ScanDataPolar(const std::vector<PointPolar>& pointPolarList, const std::chrono::time_point<std::chrono::system_clock>& timestamp)
     {
-        timestamp = std::chrono::system_clock::now();
+        this->timestamp = timestamp;
         points_mm = pointPolarList;
     }
 

--- a/src/parakeet/ScanDataPolar.cpp
+++ b/src/parakeet/ScanDataPolar.cpp
@@ -8,20 +8,20 @@ namespace mechaspin
 {
 namespace parakeet
 {
-    ScanDataPolar::ScanDataPolar(const std::vector<PointPolar>& pointPolarList, const std::chrono::time_point<std::chrono::system_clock>& timestamp)
+    ScanDataPolar::ScanDataPolar(const std::vector<PointPolar>& vectorOfPolarPoints, const std::chrono::time_point<std::chrono::system_clock>& timestampOfFirstPoint)
     {
-        this->timestamp = timestamp;
-        points_mm = pointPolarList;
+        this->timestampOfFirstPoint = timestampOfFirstPoint;
+        this->vectorOfPolarPoints = vectorOfPolarPoints;
     }
 
     const std::chrono::time_point<std::chrono::system_clock>& ScanDataPolar::getTimestamp() const
     {
-        return timestamp;
+        return timestampOfFirstPoint;
     }
 
     const std::vector<PointPolar>& ScanDataPolar::getPoints() const
     {
-        return points_mm;
+        return vectorOfPolarPoints;
     }
 }
 }

--- a/src/parakeet/ScanDataXY.cpp
+++ b/src/parakeet/ScanDataXY.cpp
@@ -8,9 +8,9 @@ namespace mechaspin
 {
 namespace parakeet
 {
-    ScanDataXY::ScanDataXY(const std::vector<PointXY>& pointXYList)
+    ScanDataXY::ScanDataXY(const std::vector<PointXY>& pointXYList, const std::chrono::time_point<std::chrono::system_clock>& timestamp)
     {
-        timestamp = std::chrono::system_clock::now();
+        this->timestamp = timestamp;
         points_mm = pointXYList;
     }
 

--- a/src/parakeet/ScanDataXY.cpp
+++ b/src/parakeet/ScanDataXY.cpp
@@ -8,20 +8,20 @@ namespace mechaspin
 {
 namespace parakeet
 {
-    ScanDataXY::ScanDataXY(const std::vector<PointXY>& pointXYList, const std::chrono::time_point<std::chrono::system_clock>& timestamp)
+    ScanDataXY::ScanDataXY(const std::vector<PointXY>& pointXYList, const std::chrono::time_point<std::chrono::system_clock>& timestampOfFirstPoint)
     {
-        this->timestamp = timestamp;
-        points_mm = pointXYList;
+        this->timestampOfFirstPoint = timestampOfFirstPoint;
+        this->vectorOfCartesianPoints = pointXYList;
     }
 
     const std::chrono::time_point<std::chrono::system_clock>& ScanDataXY::getTimestamp() const
     {
-        return timestamp;
+        return timestampOfFirstPoint;
     }
 
     const std::vector<PointXY>& ScanDataXY::getPoints() const
     {
-        return points_mm;
+        return vectorOfCartesianPoints;
     }
 }
 }

--- a/src/parakeet/SerialPort.cpp
+++ b/src/parakeet/SerialPort.cpp
@@ -78,6 +78,7 @@ namespace parakeet
         if (hPort == NULL || hPort == INVALID_HANDLE_VALUE)
         {
             //MessageBox(0, "can not open port", name, MB_OK);
+            hPort = 0;
             return false;
         }
         DCB PortDCB;
@@ -113,6 +114,7 @@ namespace parakeet
         if (!SetCommState(hPort, &PortDCB))
         {
             //MessageBox(0, "Unable to configure the serial port", "error", MB_OK);
+            hPort = 0;
             CloseHandle(hPort);
             return false;
         }
@@ -134,6 +136,7 @@ namespace parakeet
         {
             // Could not set the timeout parameters.
             //MessageBox(0, "Unable to set the timeout parameters", "error", MB_OK);
+            hPort = 0;
             CloseHandle(hPort);
             return false;
         }
@@ -191,7 +194,7 @@ namespace parakeet
             return false;
         }
 
-        SerialPortHelper::setCustomBaudRate(hPort, speed.getValue());
+        internal::SerialPortHelper::setCustomBaudRate(hPort, speed.getValue());
 
         lastUsedPort = std::string(name);
 

--- a/src/parakeet/exceptions/NotConnectedToSensorException.cpp
+++ b/src/parakeet/exceptions/NotConnectedToSensorException.cpp
@@ -1,0 +1,19 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#include <parakeet/exceptions/NotConnectedToSensorException.h>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace exceptions
+{
+    NotConnectedToSensorException::NotConnectedToSensorException() : std::runtime_error("Not connected to sensor.")
+    {
+
+    }
+}
+}
+}

--- a/src/parakeet/exceptions/UnableToDetermineBaudRateException.cpp
+++ b/src/parakeet/exceptions/UnableToDetermineBaudRateException.cpp
@@ -1,0 +1,19 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#include <parakeet/exceptions/UnableToDetermineBaudRateException.h>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace exceptions
+{
+    UnableToDetermineBaudRateException::UnableToDetermineBaudRateException() : std::runtime_error("Unable to determine baudrate.")
+    {
+
+    }
+}
+}
+}

--- a/src/parakeet/exceptions/UnableToOpenPortException.cpp
+++ b/src/parakeet/exceptions/UnableToOpenPortException.cpp
@@ -1,0 +1,19 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#include <parakeet/exceptions/UnableToOpenPortException.h>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace exceptions
+{
+    UnableToOpenPortException::UnableToOpenPortException() : std::runtime_error("Unable to connect to sensor.")
+    {
+
+    }
+}
+}
+}

--- a/src/parakeet/internal/SensorResponse.cpp
+++ b/src/parakeet/internal/SensorResponse.cpp
@@ -1,0 +1,39 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#include <parakeet/internal/SensorResponse.h>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace internal
+{
+    SensorResponse::SensorResponse(MessageType messageType, const std::string& message)
+    {
+        this->possibleResponses.push_back(message);
+        this->messageType = messageType;
+    }
+
+    SensorResponse::SensorResponse(MessageType messageType, const std::vector<std::string>& messages)
+    {
+        for(auto message : messages)
+        {
+            this->possibleResponses.push_back(message);
+        }
+        this->messageType = messageType;
+    }
+    
+    SensorResponse::MessageType SensorResponse::getMessageType() const
+    {
+        return this->messageType;
+    }
+    
+    const std::vector<std::string>& SensorResponse::getResponses() const
+    {
+        return this->possibleResponses;
+    }
+}
+}
+}

--- a/src/parakeet/internal/SensorResponseParser.cpp
+++ b/src/parakeet/internal/SensorResponseParser.cpp
@@ -2,7 +2,6 @@
 	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
 */
 
-#pragma once
 #include <parakeet/internal/SensorResponseParser.h>
 
 namespace mechaspin

--- a/src/parakeet/internal/SensorResponseParser.cpp
+++ b/src/parakeet/internal/SensorResponseParser.cpp
@@ -1,0 +1,61 @@
+/*
+	Copyright 2021 OpenJAUS, LLC (dba MechaSpin). Subject to the MIT license.
+*/
+
+#pragma once
+#include <parakeet/internal/SensorResponseParser.h>
+
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace internal
+{
+    SensorResponseParser::SensorResponseParser()
+    {
+        SensorResponse baudRate(SensorResponse::BAUDRATE, "Error: OK");
+        SensorResponse dataSmoothing(SensorResponse::DATASMOOTHING, "LiDAR set smooth ok");
+        SensorResponse dragPointRemoval(SensorResponse::DRAGPOINTREMOVAL, "LiDAR set filter ok");
+        SensorResponse intensity(SensorResponse::INTENSITY, std::vector<std::string> { "LiDAR CONFID", "LiDAR NO CONFID" });
+        SensorResponse speed(SensorResponse::SPEED, "Set RPM: OK");
+        SensorResponse start(SensorResponse::START, "LiDAR START");
+        SensorResponse stop(SensorResponse::STOP, "LiDAR STOP");
+
+        allResponses = 
+        {
+            baudRate,
+            dataSmoothing,
+            dragPointRemoval,
+            intensity,
+            speed,
+            start,
+            stop
+        };
+    }
+
+    SensorResponse SensorResponseParser::getSensorResponseFromMessage(const std::string& message)
+    {
+        for(SensorResponse response : allResponses)
+        {
+            if(doesMessageMatchResponse(message, response))
+            {
+                return response;
+            }
+        }
+        return SensorResponse(SensorResponse::NA, "");
+    }
+
+    bool SensorResponseParser::doesMessageMatchResponse(const std::string& message, const SensorResponse& response)
+    {
+        for(auto responseMessage : response.getResponses())
+        {
+            if(message.find(responseMessage) != std::string::npos)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+}
+}

--- a/src/parakeet/internal/SerialPortHelper.cpp
+++ b/src/parakeet/internal/SerialPortHelper.cpp
@@ -11,6 +11,12 @@ namespace ioctl
 }
 #include <asm/termios.h>
 
+namespace mechaspin
+{
+namespace parakeet
+{
+namespace internal
+{
 void SerialPortHelper::setCustomBaudRate(int fileDescriptor, int baudRate)
 {
     //Set baud rate, using termios2 here as termios1 does not support custom baud rates.
@@ -23,5 +29,8 @@ void SerialPortHelper::setCustomBaudRate(int fileDescriptor, int baudRate)
     tty2.c_ospeed = baudRate;
 
     ioctl::ioctl(fileDescriptor, TCSETS2, &tty2);
+}
+}
+}
 }
 #endif

--- a/src/parakeet/util.cpp
+++ b/src/parakeet/util.cpp
@@ -21,10 +21,30 @@ namespace parakeet
 
     PointXY util::transform(const PointPolar& polarPoint)
     {
-        double x = polarPoint.getRange_mm() * cos(degreesToRadians(polarPoint.getAngle_deg()));
-        double y = polarPoint.getRange_mm() * sin(degreesToRadians(polarPoint.getAngle_deg()));
+        double x_mm = polarPoint.getRange_mm() * cos(degreesToRadians(polarPoint.getAngle_deg()));
+        double y_mm = polarPoint.getRange_mm() * sin(degreesToRadians(polarPoint.getAngle_deg()));
 
-        return PointXY(x, y, polarPoint.getIntensity());
+        return PointXY(x_mm, y_mm, polarPoint.getIntensity());
+    }
+
+    ScanDataPolar util::transform(const ScanDataXY& xyScanData)
+    {
+        std::vector<PointPolar> pointPolarVector;
+
+        for(auto point : xyScanData.getPoints())
+        {
+            pointPolarVector.push_back(transform(point));
+        }
+        return ScanDataPolar(pointPolarVector, xyScanData.getTimestamp());
+    }
+
+    PointPolar util::transform(const PointXY& xyPoint)
+    {
+        double radius_mm = hypot(xyPoint.getX_mm(), xyPoint.getY_mm());
+        double angle_rad = atan2(xyPoint.getY_mm(), xyPoint.getX_mm());
+        double angle_deg = radiansToDegrees0To360(angle_rad);
+
+        return PointPolar(radius_mm, angle_deg, xyPoint.getIntensity());
     }
 }
 }

--- a/src/parakeet/util.cpp
+++ b/src/parakeet/util.cpp
@@ -16,7 +16,7 @@ namespace parakeet
         {
             pointXYvector.push_back(transform(point));
         }
-        return ScanDataXY(pointXYvector);
+        return ScanDataXY(pointXYvector, polarScanData.getTimestamp());
     }
 
     PointXY util::transform(const PointPolar& polarPoint)


### PR DESCRIPTION
## [2.0.0]
### Added
- Added sensor starting angle and spin rotation to the documentation
- Added the option to convert from ScanDataXY to ScanDataPolar
- Added a deprecation macro
### Modified
- Changed Driver code to start a ScanData set at 0 degrees, rather than 36-72 degrees
- [BREAKING] Changed ScanDataPolar / ScanDataXY to require a timestamp on creation, which signifies when the first point was created
- Changed Windows and Linux if defines to be more consistent
- Modified SimpleExample CMake to find the latest version of parakeet-sdk which can be found
- Properly labeled units of measure on variables
- Updated copyright action to call the action from inside the parakeet-devtools repo
### Deprecated
- Deprecated method PointPolar.getRange(), use PointPolar.getRange_mm()
- Deprecated method PointPolar.getAngleInDegrees(), use PointPolar.getAngle_deg()
- Deprecated method Driver.connect requiring all sensor settings. Replaced with Driver.connect which takes in a SensorConfiguration object which holds all sensor settings
